### PR TITLE
Upgrade Gatling to 3.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_cache:
 
 language: scala
 scala:
-  - 2.11.8
+  - 2.12.9
 jdk:
   - openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ language: scala
 scala:
   - 2.11.8
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ gatling-akka enables to simulate message passing between actors and measure late
 
 ## Installation
 
-For sbt users, addd following lines to build.sbt.
+For sbt users, add following lines to build.sbt.
 
 ### Scala 2.11
 
@@ -23,9 +23,9 @@ libraryDependencies ++= Seq(
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.3.0",
-  "io.gatling" % "gatling-test-framework" % "2.3.0",
-  "com.chatwork" %% "gatling-akka" % "0.1.14"
+  "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.1.3",
+  "io.gatling" % "gatling-test-framework" % "3.1.3",
+  "com.chatwork" %% "gatling-akka" % "0.1.15"
 )
 ```
 

--- a/gatling-akka/src/main/scala/com/chatwork/gatling/akka/check/AkkaCheck.scala
+++ b/gatling-akka/src/main/scala/com/chatwork/gatling/akka/check/AkkaCheck.scala
@@ -1,13 +1,14 @@
 package com.chatwork.gatling.akka.check
 
+import java.util.{ Map => JMap }
+
 import com.chatwork.gatling.akka.response.Response
 import io.gatling.commons.validation.Validation
 import io.gatling.core.session.Session
 import io.gatling.core.check.{ Check, CheckResult }
-import scala.collection.mutable
 
 case class AkkaCheck(wrapped: Check[Response]) extends Check[Response] {
   override def check(response: Response,
-                     session: Session)(implicit cache: mutable.Map[Any, Any]): Validation[CheckResult] =
+                     session: Session)(implicit preparedCache: JMap[Any, Any]): Validation[CheckResult] =
     wrapped.check(response, session)
 }

--- a/gatling-akka/src/main/scala/com/chatwork/gatling/akka/config/AkkaProtocol.scala
+++ b/gatling-akka/src/main/scala/com/chatwork/gatling/akka/config/AkkaProtocol.scala
@@ -1,6 +1,5 @@
 package com.chatwork.gatling.akka.config
 
-import akka.actor.ActorSystem
 import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol.{ Protocol, ProtocolComponents, ProtocolKey }
@@ -14,23 +13,19 @@ case class AkkaProtocol(askTimeout: FiniteDuration = 10 seconds) extends Protoco
 
 object AkkaProtocol {
 
-  val protocolKey = new ProtocolKey {
-    override type Protocol   = AkkaProtocol
-    override type Components = AkkaProtocolComponents
-
+  val protocolKey = new ProtocolKey[AkkaProtocol, AkkaProtocolComponents] {
     override def protocolClass: Class[io.gatling.core.protocol.Protocol] =
       classOf[AkkaProtocol].asInstanceOf[Class[io.gatling.core.protocol.Protocol]]
 
     override def defaultProtocolValue(configuration: GatlingConfiguration): AkkaProtocol = AkkaProtocol()
 
-    override def newComponents(system: ActorSystem,
-                               coreComponents: CoreComponents): AkkaProtocol => AkkaProtocolComponents =
+    override def newComponents(coreComponents: CoreComponents): AkkaProtocol => AkkaProtocolComponents =
       protocol => AkkaProtocolComponents(protocol)
   }
 }
 
 case class AkkaProtocolComponents(protocol: AkkaProtocol) extends ProtocolComponents {
-  override def onStart: Option[(Session) => Session] = None
+  override def onStart: Session => Session = ProtocolComponents.NoopOnStart
 
-  override def onExit: Option[(Session) => Unit] = None
+  override def onExit: Session => Unit = ProtocolComponents.NoopOnExit
 }

--- a/gatling-akka/src/main/scala/com/chatwork/gatling/akka/request/AkkaRequestBuilder.scala
+++ b/gatling-akka/src/main/scala/com/chatwork/gatling/akka/request/AkkaRequestBuilder.scala
@@ -60,6 +60,6 @@ case class AskActionBuilder(requestBuilder: AskRequestBuilder) extends ActionBui
   override def build(ctx: ScenarioContext, next: Action): Action = {
     import ctx._
     val akkaComponents: AkkaProtocolComponents = protocolComponentsRegistry.components(AkkaProtocol.protocolKey)
-    AskAction(requestBuilder.askAttributes, coreComponents, akkaComponents.protocol, system, next)
+    AskAction(requestBuilder.askAttributes, coreComponents, akkaComponents.protocol, next)
   }
 }

--- a/gatling-akka/src/test/scala/com/chatwork/gatling/akka/check/AkkaCheckSpec.scala
+++ b/gatling-akka/src/test/scala/com/chatwork/gatling/akka/check/AkkaCheckSpec.scala
@@ -1,7 +1,10 @@
 package com.chatwork.gatling.akka.check
 
+import java.util.{ HashMap => JHashMap, Map => JMap }
+
 import akka.actor.ActorRef
 import com.chatwork.gatling.akka.response.Response
+import io.gatling.commons.util.DefaultClock
 import io.gatling.commons.validation.Success
 import io.gatling.core.CoreDsl
 import io.gatling.core.check.CheckResult
@@ -10,14 +13,12 @@ import io.gatling.core.session.Session
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{ Matchers, WordSpecLike }
 
-import scala.collection.mutable
-
 class AkkaCheckSpec extends WordSpecLike with Matchers with MockitoSugar with CoreDsl with AkkaCheckSupport {
 
   implicit val configuration = GatlingConfiguration.loadForTest()
 
-  implicit def cache: mutable.Map[Any, Any] = mutable.Map.empty
-  val session                               = Session("mockSession", 0)
+  implicit def preparedCache: JMap[Any, Any] = new JHashMap
+  val session                                = Session("mockSession", 0, new DefaultClock().nowMillis)
 
   private def mockResponse(message: Any): Response = {
     Response(message, ActorRef.noSender)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
 
   object gatling {
     val versionOfScala211 = "2.2.5"
-    val versionOfScala212 = "2.3.0"
+    val versionOfScala212 = "3.1.3"
 
     val coreOfScala211 = gatling("core", versionOfScala211)
     val testFrameworkOfScala211 = gatling("test-framework", versionOfScala211)


### PR DESCRIPTION
The following Gatling 3.1 internal API updates required adaptation:
- ExitableAction requires a Clock, ClockSingleton was removed
- StatsEngine.logResponse signature has changed
- Check.check returns updated Session instead of Session update function
- ScenarioContext.system no longer exists, CoreComponents.actorSystem was added
- cache was changed in Check.check
- parameters of DefaultFindCheckBuilder have changed
- Validator.apply signature has changed
- CheckSupport was removed (with checkBuilder2Check), implicit CheckMaterializer is now required
- ProtocolKey signature has changed
- ProtocolComponents functions have changed